### PR TITLE
Add Pylint to PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,12 @@ jobs:
             pip-
       - name: Install dependencies
         run: |
+          pip install wheel
           pip install -r requirements-dev.txt
+          pip install hail gnomad
       - name: Check formatting
         run: black --check .
       - name: Check docstrings
         run: pydocstyle
+      - name: Run Pylint
+        run: pylint gnomad_mitochondria

--- a/gnomad_mitochondria/pipeline/add_annotations.py
+++ b/gnomad_mitochondria/pipeline/add_annotations.py
@@ -13,7 +13,7 @@ from gnomad.utils.annotations import age_hists_expr
 from gnomad.utils.reference_genome import add_reference_sequence
 from gnomad.utils.slack import slack_notifications
 from gnomad.utils.vep import vep_struct_to_csq
-from gnomad_qc.v3.resources.meta import meta
+from gnomad_qc.v3.resources.meta import meta  # pylint: disable=import-error
 from gnomad.resources.grch38.gnomad import POPS
 from gnomad.resources.grch38.reference_data import dbsnp, _import_dbsnp
 from gnomad_mitochondria.pipeline.annotation_descriptions import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,12 @@ add_ignore = [
   "D100", # Do not require docstrings for modules.
   "D104", # Do not require docstrings for packages (in __init__.py).
 ]
+
+[tool.pylint.messages_control]
+disable = [
+  # Ignore refactor and convention categories
+  "R",
+  "C",
+  # Allow todo/fixme comments
+  "fixme",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,20 @@ disable = [
   "C",
   # Allow todo/fixme comments
   "fixme",
+  # Warnings
+  "anomalous-backslash-in-string",
+  "cell-var-from-loop",
+  "dangerous-default-value",
+  "deprecated-method",
+  "f-string-without-interpolation",
+  "invalid-unary-operand-type",
+  "logging-fstring-interpolation",
+  "pointless-string-statement",
+  "protected-access",
+  "raise-missing-from",
+  "redefined-outer-name",
+  "unspecified-encoding",
+  "unused-argument",
+  "unused-import",
+  "unused-variable",
 ]

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,3 +1,4 @@
 black==19.10b0 # This should be kept in sync with the version in .pre-commit-config.yaml
 pip-tools
 pydocstyle[toml]==6.1.1 # This should be kept in sync with the version in .pre-commit-config.yaml
+pylint

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,8 @@
 #
 appdirs==1.4.4
     # via black
+astroid==2.8.4
+    # via pylint
 attrs==21.2.0
     # via black
 black==19.10b0
@@ -14,13 +16,23 @@ click==8.0.1
     # via
     #   black
     #   pip-tools
+isort==5.10.0
+    # via pylint
+lazy-object-proxy==1.6.0
+    # via astroid
+mccabe==0.6.1
+    # via pylint
 pathspec==0.8.1
     # via black
 pep517==0.10.0
     # via pip-tools
 pip-tools==6.1.0
     # via -r requirements-dev.in
+platformdirs==2.4.0
+    # via pylint
 pydocstyle[toml]==6.1.1
+    # via -r requirements-dev.in
+pylint==2.11.1
     # via -r requirements-dev.in
 regex==2021.4.4
     # via black
@@ -29,9 +41,18 @@ snowballstemmer==2.1.0
 toml==0.10.2
     # via
     #   black
+    #   pep517
     #   pydocstyle
+    #   pylint
 typed-ast==1.4.3
     # via black
+typing-extensions==3.10.0.2
+    # via
+    #   astroid
+    #   pylint
+wrapt==1.13.3
+    # via astroid
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip
+# setuptools


### PR DESCRIPTION
This adds Pylint to dev requirements and PR checks.

This configures Pylint to ignore any warnings present in existing code. It would be nice to eventually resolve most of those.

This also specifically ignores an import error caused by importing from gnomad_qc until there's an easier way to install gnomad_qc into the workflow environment.