### PR TITLE
Set PYTHONPATH when running Pylint in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Check docstrings
         run: pydocstyle
       - name: Run Pylint
-        run: pylint gnomad_mitochondria
+        run: python -m pylint gnomad_mitochondria

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Check docstrings
         run: pydocstyle
       - name: Run Pylint
-        run: python -m pylint gnomad_mitochondria
+        run: PYTHONPATH=$(pwd):$PYTHONPATH pylint gnomad_mitochondria


### PR DESCRIPTION
Not sure how it worked before and then suddenly started failing, but the [workflow failure](https://github.com/broadinstitute/gnomad-mitochondria/runs/4436910997?check_suite_focus=true) on #42 was due to Pyllint being unable to import a module from the gnomad_mitochondria package.

This adds the current directory to PYTHONPATH before running Pylint so that Pylint can find gnomad_mitochondria.